### PR TITLE
:sparkles: [FEAT/#38] 가게 ID 기반 해시태그 생성 API 구현

### DIFF
--- a/src/main/java/com/likelion/danchu/domain/store/controller/StoreController.java
+++ b/src/main/java/com/likelion/danchu/domain/store/controller/StoreController.java
@@ -10,16 +10,20 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.likelion.danchu.domain.hashtag.dto.request.HashtagRequest;
+import com.likelion.danchu.domain.hashtag.dto.response.HashtagResponse;
 import com.likelion.danchu.domain.store.dto.request.StoreRequest;
 import com.likelion.danchu.domain.store.dto.response.PageableResponse;
 import com.likelion.danchu.domain.store.dto.response.StoreResponse;
 import com.likelion.danchu.domain.store.exception.StoreErrorCode;
+import com.likelion.danchu.domain.store.service.StoreHashtagService;
 import com.likelion.danchu.domain.store.service.StoreService;
 import com.likelion.danchu.global.exception.CustomException;
 import com.likelion.danchu.global.response.BaseResponse;
@@ -37,6 +41,7 @@ import lombok.RequiredArgsConstructor;
 public class StoreController {
 
   private final StoreService storeService;
+  private final StoreHashtagService storeHashtagService;
 
   @Operation(
       summary = "가게 등록",
@@ -113,5 +118,27 @@ public class StoreController {
       @Parameter(description = "가게 ID", example = "1") @PathVariable Long storeId) {
     StoreResponse storeResponse = storeService.getStoreDetail(storeId);
     return ResponseEntity.ok(BaseResponse.success("가게 상세 조회에 성공했습니다.", storeResponse));
+  }
+
+  @Operation(
+      summary = "특정 가게 해시태그 등록",
+      description =
+          """
+              특정 가게에 해시태그를 등록합니다.
+
+              - 해시태그 이름은 **'#' 없이 입력해도 자동으로 붙여집니다**.
+              - 영어는 **모두 소문자로 변환**되어 저장됩니다.
+              - 이름은 **비어 있을 수 없으며**, 최소 1자 이상, 최대 10자 이하로 입력해야 합니다.
+              """)
+  @PostMapping("/{storeId}/hashtags")
+  public ResponseEntity<BaseResponse<HashtagResponse>> createHashtagForStore(
+      @Parameter(name = "storeId", description = "가게 ID", example = "1", required = true)
+          @PathVariable
+          Long storeId,
+      @Valid @RequestBody HashtagRequest hashtagRequest) {
+    HashtagResponse hashtagResponse =
+        storeHashtagService.createHashtagForStore(storeId, hashtagRequest);
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(BaseResponse.success("해시태그 생성에 성공했습니다.", hashtagResponse));
   }
 }

--- a/src/main/java/com/likelion/danchu/domain/store/repository/StoreHashtagRepository.java
+++ b/src/main/java/com/likelion/danchu/domain/store/repository/StoreHashtagRepository.java
@@ -3,7 +3,13 @@ package com.likelion.danchu.domain.store.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.likelion.danchu.domain.hashtag.entity.Hashtag;
+import com.likelion.danchu.domain.store.entity.Store;
 import com.likelion.danchu.domain.store.entity.StoreHashtag;
 
 @Repository
-public interface StoreHashtagRepository extends JpaRepository<StoreHashtag, Long> {}
+public interface StoreHashtagRepository extends JpaRepository<StoreHashtag, Long> {
+
+  // 특정 가게에 특정 해시태그가 이미 존재하는지 확인
+  boolean existsByStoreAndHashtag(Store store, Hashtag hashtag);
+}

--- a/src/main/java/com/likelion/danchu/domain/store/service/StoreHashtagService.java
+++ b/src/main/java/com/likelion/danchu/domain/store/service/StoreHashtagService.java
@@ -1,0 +1,66 @@
+package com.likelion.danchu.domain.store.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.likelion.danchu.domain.hashtag.dto.request.HashtagRequest;
+import com.likelion.danchu.domain.hashtag.dto.response.HashtagResponse;
+import com.likelion.danchu.domain.hashtag.entity.Hashtag;
+import com.likelion.danchu.domain.hashtag.exception.HashtagErrorCode;
+import com.likelion.danchu.domain.hashtag.mapper.HashtagMapper;
+import com.likelion.danchu.domain.hashtag.repository.HashtagRepository;
+import com.likelion.danchu.domain.store.entity.Store;
+import com.likelion.danchu.domain.store.entity.StoreHashtag;
+import com.likelion.danchu.domain.store.exception.StoreErrorCode;
+import com.likelion.danchu.domain.store.repository.StoreHashtagRepository;
+import com.likelion.danchu.domain.store.repository.StoreRepository;
+import com.likelion.danchu.global.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StoreHashtagService {
+
+  private final HashtagRepository hashtagRepository;
+  private final HashtagMapper hashtagMapper;
+  private final StoreRepository storeRepository;
+  private final StoreHashtagRepository storeHashtagRepository;
+
+  /**
+   * 특정 가게에 해시태그를 생성/연결하는 서비스 메서드
+   *
+   * @param storeId 해시태그를 등록할 대상 가게 ID
+   * @param request 해시태그 생성 요청 DTO
+   * @return 생성 또는 재사용된 해시태그 응답 DTO
+   * @throws CustomException 해시태그 길이가 유효하지 않거나, 가게를 찾을 수 없거나, 이미 해당 가게에 동일한 해시태그가 연결된 경우
+   */
+  public HashtagResponse createHashtagForStore(Long storeId, HashtagRequest request) {
+    String name = request.toFormattedName();
+    if (name.length() < 2 || name.length() > 11) {
+      throw new CustomException(HashtagErrorCode.HASHTAG_LENGTH_INVALID);
+    }
+
+    // 이미 존재하는 해시태그면 재사용, 없으면 새로 생성
+    Hashtag hashtag =
+        hashtagRepository
+            .findByName(name)
+            .orElseGet(() -> hashtagRepository.save(Hashtag.builder().name(name).build()));
+
+    // storeId로 가게 조회
+    Store store =
+        storeRepository
+            .findById(storeId)
+            .orElseThrow(() -> new CustomException(StoreErrorCode.STORE_NOT_FOUND));
+
+    // 해당 가게에 이미 동일 해시태그가 연결되어 있는지 확인
+    if (storeHashtagRepository.existsByStoreAndHashtag(store, hashtag)) {
+      throw new CustomException(HashtagErrorCode.HASHTAG_ALREADY_EXISTS);
+    }
+
+    storeHashtagRepository.save(StoreHashtag.builder().store(store).hashtag(hashtag).build());
+
+    return hashtagMapper.toResponse(hashtag);
+  }
+}


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) ✨ [FEAT/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- closed #38 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 가게 ID를 입력받아 해당 가게에 연결된 해시태그를 생성하도록 구현했습니다.


## 🛠 개발 상세
- `POST /api/stores/{storeId}/hashtags` API 구현
- 요청 시 가게 ID를 받아 해당 가게와 연결된 해시태그 생성
- `StoreHashtagService`를 생성하여 가게–해시태그 연관/생성 로직을 분리


## ✔️ 체크 리스트
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?

      
## 📸 스크린샷 (선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


## ➕ 추후 계획(선택)
<!-- 추가로 계획 중인 기능이나 리팩토링 예정 중인 기능이 있다면 작성해주세요 -->
