### PR TITLE
:sparkles: [FEAT/#61] 전체 미션 조회 API 구현

### DIFF
--- a/src/main/java/com/likelion/danchu/domain/mission/controller/MissionController.java
+++ b/src/main/java/com/likelion/danchu/domain/mission/controller/MissionController.java
@@ -1,10 +1,13 @@
 package com.likelion.danchu.domain.mission.controller;
 
+import java.util.List;
+
 import jakarta.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -16,6 +19,7 @@ import com.likelion.danchu.domain.mission.dto.request.MissionRequest;
 import com.likelion.danchu.domain.mission.dto.response.MissionResponse;
 import com.likelion.danchu.domain.mission.service.MissionService;
 import com.likelion.danchu.global.response.BaseResponse;
+import com.likelion.danchu.global.security.SecurityUtil;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -36,10 +40,10 @@ public class MissionController {
       summary = "미션 생성",
       description =
           """
-          새로운 미션을 등록합니다.
-          - date: **yyyy-MM-dd**
-          - image: 선택
-          """)
+              새로운 미션을 등록합니다.
+              - date: **yyyy-MM-dd**
+              - image: 선택
+              """)
   @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<BaseResponse<MissionResponse>> createMission(
       @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
@@ -53,5 +57,19 @@ public class MissionController {
     MissionResponse missionResponse = missionService.createMission(missionRequest, imageFile);
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(BaseResponse.success("미션 생성에 성공했습니다.", missionResponse));
+  }
+
+  @Operation(
+      summary = "오늘의 미션 조회 (이미 완료한 미션 제외)",
+      description =
+          """
+              - 오늘 날짜의 일일 미션만 반환합니다.
+              - 로그인 사용자가 **이미 완료한 미션은 제외**됩니다.
+              """)
+  @GetMapping("/today")
+  public ResponseEntity<BaseResponse<List<MissionResponse>>> getTodayMissions() {
+    Long userId = SecurityUtil.getCurrentUserId();
+    List<MissionResponse> responses = missionService.getTodayMissions(userId);
+    return ResponseEntity.ok(BaseResponse.success("오늘의 미션 조회 성공", responses));
   }
 }

--- a/src/main/java/com/likelion/danchu/domain/mission/repository/MissionRepository.java
+++ b/src/main/java/com/likelion/danchu/domain/mission/repository/MissionRepository.java
@@ -1,8 +1,11 @@
 package com.likelion.danchu.domain.mission.repository;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.likelion.danchu.domain.mission.entity.Mission;
@@ -12,4 +15,20 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
 
   // 지정한 가게, 날짜, 제목이 모두 일치하는 미션이 존재하는지 확인
   boolean existsByStoreIdAndDateAndTitle(Long storeId, LocalDate date, String title);
+
+  // 오늘 날짜 미션 중 해당 유저가 아직 완료 안한 미션만
+  @Query(
+      """
+        select m
+        from Mission m
+        where m.date = :today
+          and not exists (
+            select 1
+            from User u
+            where u.id = :userId
+              and m.id member of u.completedMissionIds
+          )
+      """)
+  List<Mission> findTodayNotCompleted(
+      @Param("today") LocalDate today, @Param("userId") Long userId);
 }

--- a/src/main/java/com/likelion/danchu/domain/mission/service/MissionService.java
+++ b/src/main/java/com/likelion/danchu/domain/mission/service/MissionService.java
@@ -1,5 +1,9 @@
 package com.likelion.danchu.domain.mission.service;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
 import jakarta.transaction.Transactional;
 
 import org.springframework.stereotype.Service;
@@ -13,7 +17,11 @@ import com.likelion.danchu.domain.mission.mapper.MissionMapper;
 import com.likelion.danchu.domain.mission.repository.MissionRepository;
 import com.likelion.danchu.domain.store.entity.Store;
 import com.likelion.danchu.domain.store.repository.StoreRepository;
+import com.likelion.danchu.domain.user.entity.User;
+import com.likelion.danchu.domain.user.exception.UserErrorCode;
+import com.likelion.danchu.domain.user.repository.UserRepository;
 import com.likelion.danchu.global.exception.CustomException;
+import com.likelion.danchu.global.redis.RedisUtil;
 import com.likelion.danchu.global.s3.entity.PathName;
 import com.likelion.danchu.global.s3.service.S3Service;
 
@@ -28,6 +36,8 @@ public class MissionService {
   private final S3Service s3Service;
   private final MissionRepository missionRepository;
   private final MissionMapper missionMapper;
+  private final UserRepository userRepository;
+  private final RedisUtil redisUtil;
 
   /**
    * 미션 생성 - 가게 존재 여부 검증
@@ -64,5 +74,80 @@ public class MissionService {
     Mission saved =
         missionRepository.save(missionMapper.toEntity(store, missionRequest, rewardImageUrl));
     return missionMapper.toResponse(saved);
+  }
+
+  /**
+   * 오늘 날짜의 미션 중에서 로그인 사용자가 아직 완료하지 않은 미션만 조회
+   *
+   * @param userId 로그인한 사용자 ID
+   * @return 오늘의 미완료 미션 목록을 {@link MissionResponse} 리스트로 반환
+   */
+  public List<MissionResponse> getTodayMissions(Long userId) {
+    // Asia/Seoul 타임존 기준으로 오늘 날짜 계산
+    LocalDate todayKST = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+    // 네이티브 쿼리: user_completed_mission 조인테이블을 통해 미완료만 필터링
+    return missionRepository.findTodayNotCompleted(todayKST, userId).stream()
+        .map(missionMapper::toResponse)
+        .toList();
+  }
+
+  /**
+   * 미션 완료 처리 유저의 완료 미션 ID 리스트에 missionId를 추가한다(중복 시 무시) 새로 추가된 경우에만 완료 카운트/Redis 값을 증가시킨다.
+   *
+   * @param userId 완료 처리하는 사용자 ID
+   * @param missionId 완료할 미션 ID
+   * @throws CustomException 미션 또는 사용자 미존재 시 예외 발생
+   */
+  public void completeMission(Long userId, Long missionId) {
+    // (옵션) 미션 존재 검증
+    missionRepository
+        .findById(missionId)
+        .orElseThrow(() -> new CustomException(MissionErrorCode.MISSION_NOT_FOUND));
+
+    // 사용자 조회
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+    // 완료 미션 ID 추가 (이미 있으면 false)
+    boolean added = user.addCompletedMissionId(missionId);
+    if (!added) {
+      // 이미 완료한 미션이면 아무 작업도 하지 않음 (멱등성 보장)
+      return;
+    }
+
+    // 카운트/Redis 증가 로직
+    increaseCompletedMission(userId);
+  }
+
+  /**
+   * 사용자 완료 미션 카운트를 증가시키고 Redis 값도 동기화
+   *
+   * @param userId 완료 카운트를 증가시킬 사용자 ID
+   * @throws CustomException 사용자 미존재 시 예외 발생
+   */
+  public void increaseCompletedMission(Long userId) {
+    String redisKey = "user:completedMission:" + userId;
+
+    // 1. DB에서 유저 조회
+    User user =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+    // 2. 엔티티 값 증가
+    user.increaseCompletedMission();
+
+    // 3. Redis 값 증가/초기화
+    if (redisUtil.existData(redisKey)) {
+      // Redis 값이 있으면 바로 +1
+      long newValue = redisUtil.getLongValue(redisKey) + 1;
+      redisUtil.setData(redisKey, String.valueOf(newValue));
+    } else {
+      // Redis에 없으면 DB값을 그대로 넣음
+      redisUtil.setData(redisKey, String.valueOf(user.getCompletedMission()));
+    }
   }
 }

--- a/src/main/java/com/likelion/danchu/domain/user/entity/User.java
+++ b/src/main/java/com/likelion/danchu/domain/user/entity/User.java
@@ -1,11 +1,19 @@
 package com.likelion.danchu.domain.user.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.likelion.danchu.global.common.BaseTimeEntity;
@@ -45,8 +53,27 @@ public class User extends BaseTimeEntity {
   @Column(name = "profile_image_url", nullable = true)
   private String profileImageUrl;
 
+  // 완료한 미션 ID 리스트 조인테이블로 저장
+  @Builder.Default
+  @ElementCollection(fetch = FetchType.LAZY)
+  @CollectionTable(
+      name = "user_completed_mission",
+      joinColumns = @JoinColumn(name = "user_id"),
+      uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "mission_id"}))
+  @Column(name = "mission_id", nullable = false)
+  private List<Long> completedMissionIds = new ArrayList<>();
+
   public void increaseCompletedMission() {
     this.completedMission++;
+  }
+
+  // 중복 방지하면서 missionId 추가 (추가되면 true)
+  public boolean addCompletedMissionId(Long missionId) {
+    if (!this.completedMissionIds.contains(missionId)) {
+      this.completedMissionIds.add(missionId);
+      return true;
+    }
+    return false;
   }
 
   public void updateInfo(String nickname, String email, String imageUrl) {


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) ✨ [FEAT/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- closed #61 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 전체 미션 조회 API를 구현하였습니다.


## 🛠 개발 상세
- `MissionRepository.java`
  - 오늘 날짜 미션 중 특정 유저의 완료 미션 제외 조회 쿼리 구현 (`@Query` 적용)
- `MissionService.java`
  - 오늘 미션 조회 시 완료 제외 로직
- `User.java`
  - 완료한 미션 ID를 저장하는 `@ElementCollection` 필드 추가
  - 중복 방지 로직이 포함된 `addCompletedMissionId()` 메서드 추가


## ✔️ 체크 리스트
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?

      
## 📸 스크린샷 (선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


## ➕ 추후 계획(선택)
<!-- 추가로 계획 중인 기능이나 리팩토링 예정 중인 기능이 있다면 작성해주세요 -->
