### PR TITLE
✨ [FEAT/#69] 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/likelion/danchu/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/likelion/danchu/domain/coupon/repository/CouponRepository.java
@@ -13,4 +13,8 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
   // 가장 임박한 쿠폰 → 가장 여유 있는 쿠폰 순서로 조회
   List<Coupon> findAllByExpirationDateGreaterThanEqualOrderByExpirationDateAsc(LocalDate date);
+
+  List<Coupon> findAllByUser_Id(Long userId);
+
+  void deleteAllByUser_Id(Long userId);
 }

--- a/src/main/java/com/likelion/danchu/domain/stamp/repository/StampRepository.java
+++ b/src/main/java/com/likelion/danchu/domain/stamp/repository/StampRepository.java
@@ -14,4 +14,6 @@ public interface StampRepository extends JpaRepository<Stamp, Long> {
   Optional<Stamp> findTopByUser_IdAndStore_IdOrderByIdDesc(Long userId, Long storeId);
 
   List<Stamp> findAllByUser_IdOrderByUpdatedAtDesc(Long userId);
+
+  void deleteAllByUser_Id(Long userId);
 }

--- a/src/main/java/com/likelion/danchu/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/likelion/danchu/domain/user/exception/UserErrorCode.java
@@ -16,7 +16,10 @@ public enum UserErrorCode implements BaseErrorCode {
   DUPLICATE_EMAIL("USER_0002", "이미 사용 중인 이메일입니다.", HttpStatus.BAD_REQUEST),
   IMAGE_UPLOAD_FAILED("USER_0003", "프로필 이미지 업로드에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
   USER_SAVE_FAILED("USER_0004", "회원 정보 저장에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-  USER_NOT_FOUND("USER_0005", "회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+  USER_NOT_FOUND("USER_0005", "회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+  USER_DELETE_FAILED("USER_0006", "사용자 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+  S3_DELETE_FAILED("USER_0007", "S3 이미지 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
   ;
 
   private final String code;

--- a/src/main/java/com/likelion/danchu/domain/user/repository/UserHashtagRepository.java
+++ b/src/main/java/com/likelion/danchu/domain/user/repository/UserHashtagRepository.java
@@ -13,4 +13,6 @@ public interface UserHashtagRepository extends JpaRepository<UserHashtag, Long> 
   void deleteByUser(User user);
 
   List<UserHashtag> findAllByUser(User user);
+
+  void deleteAllByUser_Id(Long userId);
 }


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) ✨ [FEAT/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- closed #69 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 회원 탈퇴 API를 구현하였습니다.


## 🛠 개발 상세
- `DELETE /api/users` API 구현
- 삭제/정리 범위
    - S3: 사용자 프로필 이미지, 사용자가 보유한 쿠폰 이미지
    - DB: userHashtag, stamp(스탬프카드), coupon(쿠폰), user(사용자)
    - Redis: refreshToken, completedMission 캐시
    - 토큰 무효화: Access Token 블랙리스트 등록, refreshToken 쿠키/Redis 삭제(즉시 로그아웃)


## ✔️ 체크 리스트
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?

      
## 📸 스크린샷 (선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


## ➕ 추후 계획(선택)
<!-- 추가로 계획 중인 기능이나 리팩토링 예정 중인 기능이 있다면 작성해주세요 -->
