### PR TITLE
♻️ [REFACTOR] 회원 완료 미션 개수 조회 API 리팩토링

### DIFF
--- a/src/main/java/com/likelion/danchu/domain/user/entity/User.java
+++ b/src/main/java/com/likelion/danchu/domain/user/entity/User.java
@@ -46,10 +46,6 @@ public class User extends BaseTimeEntity {
   @Column(name = "password", nullable = false)
   private String password;
 
-  @Builder.Default
-  @Column(name = "completed_mission", nullable = false)
-  private long completedMission = 0;
-
   @Column(name = "profile_image_url", nullable = true)
   private String profileImageUrl;
 
@@ -62,10 +58,6 @@ public class User extends BaseTimeEntity {
       uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "mission_id"}))
   @Column(name = "mission_id", nullable = false)
   private List<Long> completedMissionIds = new ArrayList<>();
-
-  public void increaseCompletedMission() {
-    this.completedMission++;
-  }
 
   // 중복 방지하면서 missionId 추가 (추가되면 true)
   public boolean addCompletedMissionId(Long missionId) {

--- a/src/main/java/com/likelion/danchu/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/likelion/danchu/domain/user/repository/UserRepository.java
@@ -3,6 +3,8 @@ package com.likelion.danchu.domain.user.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.likelion.danchu.domain.user.entity.User;
@@ -14,4 +16,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByEmail(String email);
 
   Boolean existsByNickname(String nickname);
+
+  @Query(
+      "select count(mid) "
+          + "from User u "
+          + "join u.completedMissionIds mid "
+          + "where u.id = :userId")
+  long countCompletedMissions(@Param("userId") Long userId);
 }


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) ✨ [FEAT/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- closed #63 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 완료 미션 ID 리스트를 User 엔티티에 저장하도록 변경함에 따른 코드 변경


## 🛠 개발 상세
- User 엔티티에 `@ElementCollectio` 기반 completedMissionIds 필드 추가
- 기존 completedMission 카운트 필드 제거, 리스트 크기로 개수 계산
- 미션 완료 로직을 카운트 증가 대신 ID 리스트 추가로 변경
- 완료 미션 수 캐싱을 위한 RedisUtil 의존성 제거
- markCompletedOrThrow()에서 중복 ID 추가 방지


## ✔️ 체크 리스트
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?

      
## 📸 스크린샷 (선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


## ➕ 추후 계획(선택)
<!-- 추가로 계획 중인 기능이나 리팩토링 예정 중인 기능이 있다면 작성해주세요 -->
