### PR TITLE
✨ [FEAT/#98] 맞춤형 미션 추천 API 구현

### DIFF
--- a/src/main/java/com/likelion/danchu/domain/mission/repository/MissionRepository.java
+++ b/src/main/java/com/likelion/danchu/domain/mission/repository/MissionRepository.java
@@ -58,4 +58,21 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
       value = "SELECT COUNT(*) FROM user_completed_mission WHERE mission_id = :missionId",
       nativeQuery = true)
   long countCompletionsByMissionId(@Param("missionId") Long missionId);
+
+  // 미션과 가게를 한 번에 로드 (N+1 방지)
+  @Query("SELECT m FROM Mission m JOIN FETCH m.store")
+  List<Mission> findAllWithStore();
+
+  // 특정 미션 ID 목록에 대해 각 미션의 완료한 사용자 수를 집계하여 반환
+  @Query(
+      value =
+          """
+      SELECT m.id AS missionId, COUNT(ucm.user_id) AS cnt
+      FROM mission m
+      LEFT JOIN user_completed_mission ucm ON ucm.mission_id = m.id
+      WHERE m.id IN (:missionIds)
+      GROUP BY m.id
+      """,
+      nativeQuery = true)
+  List<Object[]> findCompleteCountsByMissionIds(@Param("missionIds") List<Long> missionIds);
 }

--- a/src/main/java/com/likelion/danchu/domain/openAI/controller/OpenAIController.java
+++ b/src/main/java/com/likelion/danchu/domain/openAI/controller/OpenAIController.java
@@ -7,7 +7,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.likelion.danchu.domain.openAI.dto.response.MissionRecommendResponse;
 import com.likelion.danchu.domain.openAI.dto.response.StoreRecommendResponse;
+import com.likelion.danchu.domain.openAI.service.MissionRecommendService;
 import com.likelion.danchu.domain.openAI.service.StoreRecommendService;
 import com.likelion.danchu.global.response.BaseResponse;
 
@@ -22,35 +24,60 @@ import lombok.RequiredArgsConstructor;
 public class OpenAIController {
 
   private final StoreRecommendService storeRecommendService;
+  private final MissionRecommendService missionRecommendService;
 
   @Operation(
       summary = "맞춤형 가게 추천",
       description =
           """
-          로그인한 사용자의 취향/이력 기반으로 **최대 5개** 가게를 추천합니다.
+              로그인한 사용자의 취향/이력 기반으로 **최대 5개** 가게를 추천합니다.
 
-          처리 절차
-          1) 내부 정렬(결정 규칙)
-             - k1 = 사용자 해시태그 ∩ 가게 해시태그 개수 **내림차순**
-             - k1 동률 시 k2 = 사용자가 참여한 미션 중 해당 가게 횟수 **내림차순**
-             - 그래도 동률이면 storeId **내림차순**
-          2) 후보 5개에 한해 **임베딩 재랭킹** 수행
-             - 입력 A: 사용자 해시태그 텍스트(“#” 제거 후 공백 결합)
-             - 입력 B: 각 가게의 description + 해시태그 텍스트
-             - `text-embedding-3-small` 임베딩 코사인 유사도 기준 **내림차순**
-             - 임베딩 호출 실패 시 1)에서 얻은 순서를 그대로 사용
-          3) 응답에 가게 해시태그 포함
+              처리 절차
+              1) 내부 정렬(결정 규칙)
+                 - k1 = 사용자 해시태그 ∩ 가게 해시태그 개수 **내림차순**
+                 - k1 동률 시 k2 = 사용자가 참여한 미션 중 해당 가게 횟수 **내림차순**
+                 - 그래도 동률이면 storeId **내림차순**
+              2) 후보 5개에 한해 **임베딩 재랭킹** 수행
+                 - 입력 A: 사용자 해시태그 텍스트(“#” 제거 후 공백 결합)
+                 - 입력 B: 각 가게의 description + 해시태그 텍스트
+                 - `text-embedding-3-small` 임베딩 코사인 유사도 기준 **내림차순**
+                 - 임베딩 호출 실패 시 1)에서 얻은 순서를 그대로 사용
+              3) 응답에 가게 해시태그 포함
 
-          요청 요건
-          - **로그인 필수(JWT)**
+              요청 요건
+              - **로그인 필수(JWT)**
 
-          응답
-          - 200 OK: BaseResponse<List<StoreRecommendResponse>>
-          """)
+              응답
+              - 200 OK: BaseResponse<List<StoreRecommendResponse>>
+              """)
   @GetMapping("/stores/recommend")
   public ResponseEntity<BaseResponse<List<StoreRecommendResponse>>> recommendStores() {
 
     List<StoreRecommendResponse> result = storeRecommendService.recommendTop5StoresForCurrentUser();
     return ResponseEntity.ok(BaseResponse.success("추천 가게 5개 조회 성공", result));
+  }
+
+  @Operation(
+      summary = "맞춤형 미션 추천",
+      description =
+          """
+              로그인한 사용자의 관심 해시태그/이력 기반으로 1개의 미션을 추천합니다.
+
+              처리 절차
+              1. 기본 점수 계산
+                - 사용자 관심 해시태그와 가게 해시태그의 교집합 개수
+                - 해당 미션의 완료 횟수(인기 정도)
+                - missionId 내림차순 정렬
+                - 상위 5개 후보 선별
+              2. 임베딩 기반 재랭킹
+                - A (사용자): 사용자 해시태그를 # 제거 후 공백으로 합친 문자열
+                - B (미션): 미션 제목 + 미션 설명 + 해당 가게 해시태그
+              3. 최종 추천
+                - 재랭킹된 리스트에서 첫 번째 미션만 반환
+              """)
+  @GetMapping("/missions/recommend")
+  public ResponseEntity<BaseResponse<MissionRecommendResponse>> recommendMission() {
+    MissionRecommendResponse result = missionRecommendService.recommendTopMissionForCurrentUser();
+    return ResponseEntity.ok(BaseResponse.success("추천 미션 조회 성공", result));
   }
 }

--- a/src/main/java/com/likelion/danchu/domain/openAI/dto/response/MissionRecommendResponse.java
+++ b/src/main/java/com/likelion/danchu/domain/openAI/dto/response/MissionRecommendResponse.java
@@ -1,0 +1,23 @@
+package com.likelion.danchu.domain.openAI.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "MissionRecommendResponse DTO", description = "맞춤형 미션 추천 응답")
+public class MissionRecommendResponse {
+
+  @Schema(description = "미션 ID", example = "1")
+  private Long missionId;
+
+  @Schema(description = "미션 제목", example = "점심시간 방문 인증")
+  private String title;
+
+  @Schema(description = "미션 보상(이름/설명)", example = "사이다 1잔")
+  private String rewardName;
+
+  @Schema(description = "가게 이름", example = "동방손칼국수")
+  private String storeName;
+}

--- a/src/main/java/com/likelion/danchu/domain/openAI/service/MissionRecommendService.java
+++ b/src/main/java/com/likelion/danchu/domain/openAI/service/MissionRecommendService.java
@@ -1,0 +1,202 @@
+package com.likelion.danchu.domain.openAI.service;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.likelion.danchu.domain.hashtag.entity.Hashtag;
+import com.likelion.danchu.domain.mission.entity.Mission;
+import com.likelion.danchu.domain.mission.exception.MissionErrorCode;
+import com.likelion.danchu.domain.mission.repository.MissionRepository;
+import com.likelion.danchu.domain.openAI.dto.response.MissionRecommendResponse;
+import com.likelion.danchu.domain.openAI.exception.OpenAIErrorCode;
+import com.likelion.danchu.domain.store.entity.Store;
+import com.likelion.danchu.domain.store.repository.StoreHashtagRepository;
+import com.likelion.danchu.domain.user.entity.UserHashtag;
+import com.likelion.danchu.domain.user.exception.UserErrorCode;
+import com.likelion.danchu.domain.user.repository.UserHashtagRepository;
+import com.likelion.danchu.domain.user.repository.UserRepository;
+import com.likelion.danchu.global.exception.CustomException;
+import com.likelion.danchu.global.openAI.OpenAIUtil;
+import com.likelion.danchu.global.security.SecurityUtil;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 맞춤형 미션 추천 서비스 (단일 추천).
+ *
+ * <p>알고리즘:
+ *
+ * <ol>
+ *   <li>k1: 사용자 해시태그 ∩ 가게 해시태그 개수
+ *   <li>k2: 미션 완료(인기) 추정치(없으면 0)
+ *   <li>정렬키: (k1 desc, k2 desc, missionId desc) 로 1차 후보 상위 5개
+ *   <li>후보 5개에 대해 임베딩 코사인 유사도 재랭킹(실패 시 1차 순서 유지)
+ * </ol>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MissionRecommendService {
+
+  private static final int TOP_K = 5;
+
+  private final OpenAIUtil openAIUtil;
+  private final UserRepository userRepository;
+  private final UserHashtagRepository userHashtagRepository;
+  private final MissionRepository missionRepository;
+  private final StoreHashtagRepository storeHashtagRepository;
+
+  /** 로그인 사용자에게 미션 1개를 추천 */
+  public MissionRecommendResponse recommendTopMissionForCurrentUser() {
+    Long userId =
+        Optional.ofNullable(SecurityUtil.getCurrentUserId())
+            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+
+    // 1) 사용자 관심 해시태그
+    List<String> userTags =
+        userHashtagRepository.findByUser_Id(userId).stream()
+            .map(UserHashtag::getHashtag)
+            .map(Hashtag::getName)
+            .distinct()
+            .toList();
+    if (userTags.isEmpty()) {
+      throw new CustomException(OpenAIErrorCode.USER_HASHTAG_EMPTY);
+    }
+
+    // 2) 미션 + 스토어(fetch-join)
+    List<Mission> allMissions = missionRepository.findAllWithStore();
+    if (allMissions.isEmpty()) {
+      throw new CustomException(MissionErrorCode.MISSION_NOT_FOUND);
+    }
+
+    // 2-1) 스토어 해시태그 일괄 조회
+    List<Long> storeIds = allMissions.stream().map(m -> m.getStore().getId()).distinct().toList();
+
+    Map<Long, List<String>> storeTagMap =
+        storeHashtagRepository.findByStore_IdIn(storeIds).stream()
+            .collect(
+                Collectors.groupingBy(
+                    sh -> sh.getStore().getId(),
+                    Collectors.mapping(sh -> sh.getHashtag().getName(), Collectors.toList())));
+
+    // 2-2) 미션별 완료 수(k2) 일괄 집계
+    List<Long> missionIds = allMissions.stream().map(Mission::getId).toList();
+    Map<Long, Long> k2Map =
+        missionRepository.findCompleteCountsByMissionIds(missionIds).stream()
+            .collect(
+                Collectors.toMap(
+                    r -> ((Number) r[0]).longValue(), // missionId
+                    r -> ((Number) r[1]).longValue() // completed count
+                    ));
+
+    // 3) 스코어링(k1: 태그 교집합 수, k2: 완료 수)
+    Set<String> u = new HashSet<>(userTags);
+    record Sc(Mission m, int k1, long k2) {}
+
+    List<Sc> scored =
+        allMissions.stream()
+            .map(
+                m -> {
+                  List<String> tags = storeTagMap.getOrDefault(m.getStore().getId(), List.of());
+                  int k1 = (int) tags.stream().filter(u::contains).count();
+                  long k2 = k2Map.getOrDefault(m.getId(), 0L);
+                  return new Sc(m, k1, k2);
+                })
+            .toList();
+
+    // 4) 1차 후보 상위 TOP_K
+    List<Mission> candidates =
+        scored.stream()
+            .sorted(
+                (a, b) -> {
+                  int c = Integer.compare(b.k1, a.k1);
+                  if (c != 0) {
+                    return c;
+                  }
+                  c = Long.compare(b.k2, a.k2);
+                  if (c != 0) {
+                    return c;
+                  }
+                  return Long.compare(b.m().getId(), a.m().getId());
+                })
+            .limit(TOP_K)
+            .map(Sc::m)
+            .toList();
+
+    if (candidates.isEmpty()) {
+      throw new CustomException(MissionErrorCode.MISSION_NOT_FOUND);
+    }
+
+    // 5) 임베딩 재랭킹(user text vs mission text)
+    String userText = normalizeTags(userTags);
+    List<String> missionTexts =
+        candidates.stream()
+            .map(
+                m -> buildMissionText(m, storeTagMap.getOrDefault(m.getStore().getId(), List.of())))
+            .toList();
+
+    List<Mission> finalOrder = candidates;
+    try {
+      List<String> inputs = new ArrayList<>(1 + missionTexts.size());
+      inputs.add(userText);
+      inputs.addAll(missionTexts);
+
+      var vecs = openAIUtil.embedAll(inputs); // [0] user, 이후 후보 미션들
+      if (vecs.size() == inputs.size()) {
+        double[] uvec = vecs.get(0);
+        record Rank(Mission m, double sim) {}
+
+        List<Rank> ranks = new ArrayList<>();
+        for (int i = 0; i < candidates.size(); i++) {
+          double sim = OpenAIUtil.cosine(uvec, vecs.get(i + 1));
+          ranks.add(new Rank(candidates.get(i), sim));
+        }
+        ranks.sort((x, y) -> Double.compare(y.sim, x.sim));
+        finalOrder = ranks.stream().map(Rank::m).toList();
+      } else {
+        log.warn("[Embeddings] size mismatch: expected={}, got={}", inputs.size(), vecs.size());
+      }
+    } catch (Exception e) {
+      log.warn("[Embeddings] fallback to deterministic order. cause={}", e.toString());
+    }
+
+    // 6) 최종 1개만 DTO로 반환
+    Mission top = finalOrder.get(0);
+    return toDto(top);
+  }
+
+  /** "#태그"들을 공백으로 연결한 텍스트 */
+  private String normalizeTags(List<String> tags) {
+    return tags.stream()
+        .map(t -> t.startsWith("#") ? t.substring(1) : t)
+        .collect(Collectors.joining(" "));
+  }
+
+  /** 미션 텍스트(제목 + 설명 + 가게 태그) */
+  private String buildMissionText(Mission m, List<String> storeTags) {
+    String title = Optional.ofNullable(m.getTitle()).orElse("");
+    String desc = Optional.ofNullable(m.getDescription()).orElse("");
+    String tagStr = normalizeTags(storeTags);
+    return (title + " " + desc + " " + tagStr).trim();
+  }
+
+  private MissionRecommendResponse toDto(Mission m) {
+    Store s = m.getStore();
+    return MissionRecommendResponse.builder()
+        .missionId(m.getId())
+        .title(m.getTitle())
+        .rewardName(m.getReward())
+        .storeName(s != null ? s.getName() : null)
+        .build();
+  }
+}


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) ✨ [FEAT/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- closed #98 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 맞춤형 미션 추천 API를 구현하였습니다.


## 🛠 개발 상세
- 로그인한 사용자의 관심 해시태그/이력 기반으로 1개의 미션을 추천합니다.
- `GET /api/openai/missions/recommend` API 구현

[처리 절차]
1. 기본 점수 계산
   - 사용자 관심 해시태그와 가게 해시태그의 교집합 개수
   - 해당 미션의 완료 횟수(인기 정도)
    - missionId 내림차순 정렬
    - 상위 5개 후보 선별

2. 임베딩 기반 재랭킹
    - A (사용자): 사용자 해시태그를 # 제거 후 공백으로 합친 문자열
    - B (미션): 미션 제목 + 미션 설명 + 해당 가게 해시태그
           
 3. 최종 추천
    - 재랭킹된 리스트에서 첫 번째 미션만 반환


## ✔️ 체크 리스트
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?

      
## 📸 스크린샷 (선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


## ➕ 추후 계획(선택)
<!-- 추가로 계획 중인 기능이나 리팩토링 예정 중인 기능이 있다면 작성해주세요 -->
