### PR TITLE
♻️ [REFACTOR/#126] 가게 이름 검색 / 가게 거리순 조회 응답 구조 통일

### DIFF
--- a/src/main/java/com/likelion/danchu/domain/store/controller/StoreController.java
+++ b/src/main/java/com/likelion/danchu/domain/store/controller/StoreController.java
@@ -109,12 +109,22 @@ public class StoreController {
       summary = "가게 이름 검색",
       description = "검색어(keyword)를 기반으로 가게 이름에 해당 키워드가 포함된 가게 목록을 조회합니다.")
   @GetMapping("/search")
-  public ResponseEntity<BaseResponse<PageableResponse<StoreResponse>>> searchStoresByKeyword(
-      @RequestParam String keyword,
-      @RequestParam(defaultValue = "0") int page,
-      @RequestParam(defaultValue = "3") int size) {
-    PageableResponse<StoreResponse> storeResponse =
-        storeService.searchStoresByKeyword(keyword, page, size);
+  public ResponseEntity<BaseResponse<PageableResponse<StoreDistanceResponse>>>
+      searchStoresByKeyword(
+          @RequestParam String keyword,
+          @Parameter(description = "사용자 위도", example = "37.4881292540693")
+              @RequestParam(required = false)
+              Double lat,
+          @Parameter(description = "사용자 경도", example = "127.111066039437")
+              @RequestParam(required = false)
+              Double lng,
+          @Parameter(description = "페이지 번호(0부터 시작)", example = "0")
+              @RequestParam(defaultValue = "0")
+              int page,
+          @Parameter(description = "페이지 크기", example = "3") @RequestParam(defaultValue = "3")
+              int size) {
+    PageableResponse<StoreDistanceResponse> storeResponse =
+        storeService.searchStoresByKeyword(keyword, page, size, lat, lng);
 
     return ResponseEntity.ok(BaseResponse.success("가게 검색에 성공했습니다.", storeResponse));
   }

--- a/src/main/java/com/likelion/danchu/global/util/DistanceUtils.java
+++ b/src/main/java/com/likelion/danchu/global/util/DistanceUtils.java
@@ -1,0 +1,38 @@
+package com.likelion.danchu.global.util;
+
+public class DistanceUtils {
+
+  private static final double EARTH_RADIUS_METERS = 6371000.0; // 지구 반지름 (m)
+
+  /** 위도, 경도로 두 지점 간 거리를 계산 (meter 단위). */
+  public static double haversineMeters(double lat1, double lon1, double lat2, double lon2) {
+    double dLat = Math.toRadians(lat2 - lat1);
+    double dLon = Math.toRadians(lon2 - lon1);
+
+    double a =
+        Math.sin(dLat / 2) * Math.sin(dLat / 2)
+            + Math.cos(Math.toRadians(lat1))
+                * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLon / 2)
+                * Math.sin(dLon / 2);
+
+    double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+    return EARTH_RADIUS_METERS * c;
+  }
+
+  /** 위도, 경도로 두 지점 간 거리를 km 단위로 계산. */
+  public static double haversineKm(double lat1, double lon1, double lat2, double lon2) {
+    return haversineMeters(lat1, lon1, lat2, lon2) / 1000.0;
+  }
+
+  /** 소수점 1자리 반올림 */
+  public static double round1(double value) {
+    return Math.round(value * 10.0) / 10.0;
+  }
+
+  /** 소수점 2자리 반올림 */
+  public static double round2(double value) {
+    return Math.round(value * 100.0) / 100.0;
+  }
+}


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) ✨ [FEAT/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- closed #126 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 가게 이름 검색 API와 현재 위치 기준 거리순 조회 API의 응답 구조를 통일합니다.


## 🛠 개발 상세
- 검색 결과에도 `distanceMeters`, `distanceKm`를 포함하도록 수정 (위치 없으면 null)
- `res.data.data.content[i].store` 경로로 통일


## ✔️ 체크 리스트
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?

      
## 📸 스크린샷 (선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


## ➕ 추후 계획(선택)
<!-- 추가로 계획 중인 기능이나 리팩토링 예정 중인 기능이 있다면 작성해주세요 -->
