### PR TITLE
♻️ [REFACTOR/#141] 가게 목록 페이징 응답 구조 수정

### DIFF
--- a/src/main/java/com/likelion/danchu/domain/store/controller/StoreController.java
+++ b/src/main/java/com/likelion/danchu/domain/store/controller/StoreController.java
@@ -23,6 +23,7 @@ import com.likelion.danchu.domain.hashtag.dto.response.HashtagResponse;
 import com.likelion.danchu.domain.store.dto.request.StoreRequest;
 import com.likelion.danchu.domain.store.dto.response.PageableResponse;
 import com.likelion.danchu.domain.store.dto.response.StoreDistanceResponse;
+import com.likelion.danchu.domain.store.dto.response.StoreListItemResponse;
 import com.likelion.danchu.domain.store.dto.response.StoreResponse;
 import com.likelion.danchu.domain.store.exception.StoreErrorCode;
 import com.likelion.danchu.domain.store.service.StoreHashtagService;
@@ -98,10 +99,11 @@ public class StoreController {
               - size : 페이지 당 보여줄 가게 수입니다. (기본값: 3)
               """)
   @GetMapping
-  public ResponseEntity<BaseResponse<PageableResponse<StoreResponse>>> getPaginatedStores(
+  public ResponseEntity<BaseResponse<PageableResponse<StoreListItemResponse>>> getPaginatedStores(
       @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "3") int size) {
 
-    PageableResponse<StoreResponse> storeResponses = storeService.getPaginatedStores(page, size);
+    PageableResponse<StoreListItemResponse> storeResponses =
+        storeService.getPaginatedStores(page, size);
     return ResponseEntity.ok(BaseResponse.success("가게 페이징 조회에 성공했습니다.", storeResponses));
   }
 

--- a/src/main/java/com/likelion/danchu/domain/store/dto/response/StoreListItemResponse.java
+++ b/src/main/java/com/likelion/danchu/domain/store/dto/response/StoreListItemResponse.java
@@ -1,0 +1,18 @@
+package com.likelion.danchu.domain.store.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(title = "StoreListItemResponse", description = "목록 아이템(가게 정보를 store로 래핑)")
+public class StoreListItemResponse {
+
+  @Schema(description = "가게 정보", requiredMode = Schema.RequiredMode.REQUIRED)
+  private StoreResponse store;
+}

--- a/src/main/java/com/likelion/danchu/domain/store/mapper/StoreMapper.java
+++ b/src/main/java/com/likelion/danchu/domain/store/mapper/StoreMapper.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import com.likelion.danchu.domain.hashtag.dto.response.HashtagResponse;
 import com.likelion.danchu.domain.menu.dto.response.MenuResponse;
 import com.likelion.danchu.domain.store.dto.request.StoreRequest;
+import com.likelion.danchu.domain.store.dto.response.StoreListItemResponse;
 import com.likelion.danchu.domain.store.dto.response.StoreResponse;
 import com.likelion.danchu.domain.store.entity.Store;
 
@@ -71,5 +72,15 @@ public class StoreMapper {
 
   public StoreResponse toResponse(Store store) {
     return toResponse(store, List.of(), List.of());
+  }
+
+  // StoreResponse를 store로 감싼 목록 아이템으로 변환
+  public StoreListItemResponse toListItem(
+      Store store, List<HashtagResponse> hashtags, List<MenuResponse> menus) {
+    return StoreListItemResponse.builder().store(toResponse(store, hashtags, menus)).build();
+  }
+
+  public StoreListItemResponse toListItem(Store store, List<HashtagResponse> hashtags) {
+    return StoreListItemResponse.builder().store(toResponse(store, hashtags)).build();
   }
 }


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) ✨ [FEAT/#1] 로그인 페이지 UI 구현 -->

## 🚀 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- closed #141 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 가게 목록 페이징 조회 API 응답 구조를 `content` 배열 내부의 가게 정보를 `store` 객체로 한 번 더 감싸도록 수정했습니다.

## 🛠 개발 상세
- `StoreListItemResponse` DTO 추가 (`store` 필드로 `StoreResponse` 감싸기)
- `StoreMapper`에 `toListItem` 매핑 메서드 추가
- `StoreService#getPaginatedStores` 반환 타입을 `PageableResponse<StoreListItemResponse>`로 변경
- `StoreController`의 가게 목록 조회 응답 타입 수정

## ✔️ 체크 리스트
- [x] Merge 하려는 PR 및 Commit들을 로컬에서 실행했을 때 에러가 발생하지 않았는가?

      
## 📸 스크린샷 (선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->


## ➕ 추후 계획(선택)
<!-- 추가로 계획 중인 기능이나 리팩토링 예정 중인 기능이 있다면 작성해주세요 -->
